### PR TITLE
Fix publishing of product descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Contains the ~~VSTS~~ Azure DevOps Services (or TFS) extension that integrates [Augurk](https://augurk.github.io) into the Azure DevOps (Server) environment.
 
 [![Build Status](https://dev.azure.com/augurk/Augurk/_apis/build/status/Augurk.vsts-extension)](https://dev.azure.com/augurk/Augurk/_build/latest?definitionId=1)
+![Release Release Status](https://vsrm.dev.azure.com/augurk/_apis/public/Release/badge/5a86f7f3-d9bb-4198-9b43-bbb7d066dd90/1/4)
 
 # Prerequisites
 This repository requires the following to be installed on your machine:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,64 @@
 # vsts-extension
-Contains the ~~VSTS~~ Azure DevOps Services (or TFS) extension that integrates Augurk into the Azure DevOps Services/TFS environment.
+Contains the ~~VSTS~~ Azure DevOps Services (or TFS) extension that integrates [Augurk](https://augurk.github.io) into the Azure DevOps (Server) environment.
 
 [![Build Status](https://dev.azure.com/augurk/Augurk/_apis/build/status/Augurk.vsts-extension)](https://dev.azure.com/augurk/Augurk/_build/latest?definitionId=1)
+
+# Prerequisites
+This repository requires the following to be installed on your machine:
+- NodeJS (suggest using LTS version)
+- TypeScript (npm i -g typescript)
+- Mocha (npm i -g mocha)
+
+# Contents
+This extension consists of several tasks that can be used with Azure Pipelines (both build and release pipelines) which allows the user to interact with Augurk.
+
+- AugurkCLI: Performs a command supported by the [Augurk CLI](https://github.com/augurk/Augurk.CommandLine)
+- AugurkCLIInstaller: Downloads and installs a specific version of the Augurk CLI onto the build agent
+- AugurkCSharpAnalyzer: Uses the [Augurk.CSharpAnalyzer](https://github.com/augurk/Augurk.CSharpAnalyzer) to perform static code analysis and uploads the results to Augurk.
+- AugurkCSharpAnalyzerInstaller: Downloads and installs a specific version of the Augurk.CSharpAnalyzer onto the build agent
+- PublishFeaturesToAugurk: A legacy PowerShell based version of the AugurkCLI task that supports versions of Augurk.CLI < 4.0.0
+
+# Build and run
+To build and run a task, move into its appropriate directory (see above) and run the following commands:
+
+```shell
+tsc
+node <task-name>.js
+```
+
+For example, to build and run the AugurkCLI task, use this command:
+
+```shell
+tsc
+node cli.js
+```
+
+Obviously this will fail since the required inputs aren't set. These can be set by using environment variables. To discover the available inputs, check the **task.json**. To set the input, set an environment variable with the name INPUT_*input-name*. For example, to set the command to run for the Augurk CLI:
+
+```shell
+# In PowerShell
+$env:INPUT_COMMAND=publish
+
+# In Bash (or a simular shell)
+export INPUT_COMMAND=publish
+```
+
+# Running tests
+In order to run tests for this project, move into the folder of the appropriate task (see above) and run the following commands:
+
+```shell
+tsc
+mocha tests/_suite.js
+```
+
+# Versioning
+Important to know is that with Azure DevOps extensions there are several levels of versioning. First of all there is the version of the extension itself. We set this using [GitVersion](https://gitversion.readthedocs.io), which calculates a [semantic version](https://semver.org/) number based on Git history. This is done automatically by the build and release pipeline.
+
+Additionally the build tasks themselves are also versioned, indepedently of the extension. These version numbers must be set manually when making changes to the build task in order for the new version to be used during a build or release. This is because the build tasks are cached by the build agents.
+
+In general, when making non breaking changes (ie. no new or renamed inputs), bumping the patch version should suffice. When new features are being added that require new inputs in the **task.json**, but the task will continue to work without them, the minor version should be bumped. Finally, if new inputs are required, or if existing inputs are renamed, the major version should be updated. This allows users of the task to gracefully upgrade to the new version.
+
+# Testing the extension
+Once satisfied with the changes, create a pull request on GitHub. This will trigger an automatic build and publishes a preview version of the extension (with a monotonically updating version number). This version is then automatically used within our own Azure DevOps organization.
+
+The preview extension currently isn't publicly available. If there is a demand we can look at making it publicly available, or sharing it with specific accounts.

--- a/src/build-task/AugurkCLI/package-lock.json
+++ b/src/build-task/AugurkCLI/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@types/mocha": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-      "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",
+      "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==",
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
-      "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
+      "version": "10.14.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.5.tgz",
+      "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==",
       "dev": true
     },
     "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
     "azure-pipelines-task-lib": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
-      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
@@ -73,9 +73,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "shelljs": {
       "version": "0.3.0",

--- a/src/build-task/AugurkCLI/package.json
+++ b/src/build-task/AugurkCLI/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/augurk/vsts-extension#readme",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.7.7"
+    "azure-pipelines-task-lib": "^2.8.0"
   },
   "devDependencies": {
-    "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.15",
-    "@types/q": "^1.5.1"
+    "@types/mocha": "^5.2.6",
+    "@types/node": "^10.14.5",
+    "@types/q": "^1.5.2"
   }
 }

--- a/src/build-task/AugurkCLI/publishCommand.ts
+++ b/src/build-task/AugurkCLI/publishCommand.ts
@@ -42,7 +42,7 @@ async function publishUsingFolderStructure(featureFiles: string[], productDescri
         const publishCommand = buildBaseToolRunner("publish");
         publishCommand.arg(['--featureFiles', groupedFeatures[key].join(',')]);
         publishCommand.arg(['--groupName', key]);
-        publishCommand.argIf(productDescription != null, ['--productDescription', productDescription]);
+        publishCommand.argIf(productDescription != null, ['--productDesc', productDescription]);
 
         const publishResult = await publishCommand.exec();
         if (publishResult !== 0) {
@@ -57,7 +57,7 @@ async function publishUsingFolderStructure(featureFiles: string[], productDescri
 async function publishIndividualGroup(featureFiles: string[], productDescription: string | null) {
     const publishCommand = buildBaseToolRunner('publish');
     publishCommand.arg(['--featureFiles', featureFiles.join(',')]);
-    publishCommand.argIf(productDescription != null, ['--productDescription', productDescription]);
+    publishCommand.argIf(productDescription != null, ['--productDesc', productDescription]);
 
     const publishResult = await publishCommand.exec();
     if (publishResult !== 0) {

--- a/src/build-task/AugurkCLI/task.json
+++ b/src/build-task/AugurkCLI/task.json
@@ -8,7 +8,7 @@
   "version": {
     "Major": 0,
     "Minor": 3,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "augurk-cli"

--- a/src/build-task/AugurkCLI/task.json
+++ b/src/build-task/AugurkCLI/task.json
@@ -8,7 +8,7 @@
   "version": {
     "Major": 0,
     "Minor": 3,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [
     "augurk-cli"

--- a/src/build-task/AugurkCLI/task.json
+++ b/src/build-task/AugurkCLI/task.json
@@ -8,7 +8,7 @@
   "version": {
     "Major": 0,
     "Minor": 3,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [
     "augurk-cli"
@@ -69,7 +69,7 @@
       "label": "Group Name",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Name of the group to operate on in Augurk, or empty to operate on all groups within the provided product.",
+      "helpMarkDown": "Name of the group to operate on in Augurk. NOTE: For the publish command this is required, for the other commands it is optional.",
       "properties": {
         "EditableOptions": "True"
       },

--- a/src/build-task/AugurkCLI/tests/_suite.ts
+++ b/src/build-task/AugurkCLI/tests/_suite.ts
@@ -23,6 +23,7 @@ describe('Augurk CLI Task', function () {
         assert.equal(tr.succeeded, true, 'should have succeeded');
         assert.equal(tr.warningIssues.length, 0, "should have no warnings");
         assert.equal(tr.errorIssues.length, 0, "should have no errors");
+        console.log(tr.cmdlines);
         done();
     });
 

--- a/src/build-task/AugurkCLI/tests/_suite.ts
+++ b/src/build-task/AugurkCLI/tests/_suite.ts
@@ -30,6 +30,19 @@ describe('Augurk CLI Task', function () {
             assert.equal(tr.errorIssues.length, 0, "should have no errors");
             done();
         });
+
+        it('logs warning if multiple product descriptions found', function(done: MochaDone) {
+            this.timeout(1000);
+        
+            let tp = path.join(__dirname, 'publish-multiple-product-descriptions.js');
+            let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+            tr.run();
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.warningIssues.length, 1, "should have a warning");
+            assert.equal(tr.errorIssues.length, 0, "should have no errors");
+            done();
+        });
     });
 
     describe('Delete command', function() {

--- a/src/build-task/AugurkCLI/tests/_suite.ts
+++ b/src/build-task/AugurkCLI/tests/_suite.ts
@@ -4,70 +4,63 @@ import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('Augurk CLI Task', function () {
 
-    before( function() {
-
+    describe('Publish command', function() {
+        it('should succesfully publish', function(done: MochaDone) {
+            this.timeout(1000);
+        
+            let tp = path.join(__dirname, 'publish.js');
+            let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+            tr.run();
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+            assert.equal(tr.errorIssues.length, 0, "should have no errors");
+            done();
+        });
+    
+        it('should succesfully publish an individual group', function(done: MochaDone) {
+            this.timeout(1000);
+        
+            let tp = path.join(__dirname, 'publish-individual-group.js');
+            let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+            tr.run();
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+            assert.equal(tr.errorIssues.length, 0, "should have no errors");
+            done();
+        });
     });
 
-    after(() => {
-
+    describe('Delete command', function() {
+        it('it should succesfully delete', function(done: MochaDone) {
+            this.timeout(1000);
+        
+            let tp = path.join(__dirname, 'delete.js');
+            let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+            tr.run();
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+            assert.equal(tr.errorIssues.length, 0, "should have no errors");
+        
+            done();
+        });
     });
 
-    it('should succesfully publish', function(done: MochaDone) {
-        this.timeout(1000);
-    
-        let tp = path.join(__dirname, 'publish.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
-        tr.run();
-        console.log(tr.succeeded);
-        assert.equal(tr.succeeded, true, 'should have succeeded');
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        console.log(tr.cmdlines);
-        done();
-    });
-
-    it('should succesfully publish an individual group', function(done: MochaDone) {
-        this.timeout(1000);
-    
-        let tp = path.join(__dirname, 'publish-individual-group.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
-        tr.run();
-        console.log(tr.succeeded);
-        assert.equal(tr.succeeded, true, 'should have succeeded');
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
-    });
-
-    it('it should succesfully delete', function(done: MochaDone) {
-        this.timeout(1000);
-    
-        let tp = path.join(__dirname, 'delete.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
-        tr.run();
-        console.log(tr.succeeded);
-        assert.equal(tr.succeeded, true, 'should have succeeded');
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    
-        done();
-    });
-
-    it('it should succesfully prune', function(done: MochaDone) {
-        this.timeout(1000);
-    
-        let tp = path.join(__dirname, 'prune.js');
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
-        tr.run();
-        console.log(tr.succeeded);
-        assert.equal(tr.succeeded, true, 'should have succeeded');
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-    
-        done();
+    describe('Prune command', function() {
+        it('it should succesfully prune', function(done: MochaDone) {
+            this.timeout(1000);
+        
+            let tp = path.join(__dirname, 'prune.js');
+            let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+            tr.run();
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.warningIssues.length, 0, "should have no warnings");
+            assert.equal(tr.errorIssues.length, 0, "should have no errors");
+        
+            done();
+        });
     });
 });

--- a/src/build-task/AugurkCLI/tests/publish-individual-group.ts
+++ b/src/build-task/AugurkCLI/tests/publish-individual-group.ts
@@ -10,6 +10,7 @@ tmr.setInput('augurkInstance', 'SomeAugurkInstance');
 tmr.setInput('productName', 'Augurk');
 tmr.setInput('groupName', 'Configuration');
 tmr.setInput('useFolderStructure', 'false');
+tmr.setInput('includeProductDescription', 'false');
 
 process.env["ENDPOINT_URL_SomeAugurkInstance"] = "https://some.augurk.instance";
 

--- a/src/build-task/AugurkCLI/tests/publish-multiple-product-descriptions.ts
+++ b/src/build-task/AugurkCLI/tests/publish-multiple-product-descriptions.ts
@@ -1,0 +1,41 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'cli.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('command', 'publish');
+tmr.setInput('features', '**/*.feature');
+tmr.setInput('augurkInstance', 'SomeAugurkInstance');
+tmr.setInput('productName', 'Augurk');
+tmr.setInput('groupName', 'Configuration');
+tmr.setInput('useFolderStructure', 'false');
+tmr.setInput('includeProductDescription', 'true');
+tmr.setInput('productDescription', '**/*.md');
+
+process.env["ENDPOINT_URL_SomeAugurkInstance"] = "https://some.augurk.instance";
+
+tmr.setAnswers({
+    findMatch: {
+        "**/*.feature": [
+            "RetentionPolicy.feature",
+        ],
+        "**/*.md": [
+            "product-description-1.md",
+            "product-description-2.md"
+        ]
+    },
+    which: {
+        "augurk": "/some/path/to/augurk"
+    },
+    checkPath: {
+        "/some/path/to/augurk": true
+    },
+    exec: {
+        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --groupName Configuration --featureFiles RetentionPolicy.feature --productDescription product-description-1.md": {
+            code: 0,
+        },
+    }
+});
+
+tmr.run();

--- a/src/build-task/AugurkCLI/tests/publish-multiple-product-descriptions.ts
+++ b/src/build-task/AugurkCLI/tests/publish-multiple-product-descriptions.ts
@@ -32,7 +32,7 @@ tmr.setAnswers({
         "/some/path/to/augurk": true
     },
     exec: {
-        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --groupName Configuration --featureFiles RetentionPolicy.feature --productDescription product-description-1.md": {
+        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --groupName Configuration --featureFiles RetentionPolicy.feature --productDesc product-description-1.md": {
             code: 0,
         },
     }

--- a/src/build-task/AugurkCLI/tests/publish.ts
+++ b/src/build-task/AugurkCLI/tests/publish.ts
@@ -10,7 +10,7 @@ tmr.setInput('augurkInstance', 'SomeAugurkInstance');
 tmr.setInput('productName', 'Augurk');
 tmr.setInput('useFolderStructure', 'true');
 tmr.setInput('includeProductDescription', 'true');
-tmr.setInput('productDescription', 'produt-description.md');
+tmr.setInput('productDescription', 'product-description.md');
 
 process.env["ENDPOINT_URL_SomeAugurkInstance"] = "https://some.augurk.instance";
 
@@ -19,6 +19,9 @@ tmr.setAnswers({
         "**/*.feature": [
             "Configuration/RetentionPolicy.feature",
             "Gherkin/ChildOfTag.feature",
+        ],
+        "product-description.md": [
+            "product-description.md"
         ]
     },
     which: {

--- a/src/build-task/AugurkCLI/tests/publish.ts
+++ b/src/build-task/AugurkCLI/tests/publish.ts
@@ -9,6 +9,8 @@ tmr.setInput('features', '**/*.feature');
 tmr.setInput('augurkInstance', 'SomeAugurkInstance');
 tmr.setInput('productName', 'Augurk');
 tmr.setInput('useFolderStructure', 'true');
+tmr.setInput('includeProductDescription', 'true');
+tmr.setInput('productDescription', 'produt-description.md');
 
 process.env["ENDPOINT_URL_SomeAugurkInstance"] = "https://some.augurk.instance";
 
@@ -26,10 +28,10 @@ tmr.setAnswers({
         "/some/path/to/augurk": true
     },
     exec: {
-        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Configuration/RetentionPolicy.feature --groupName Configuration": {
+        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Configuration/RetentionPolicy.feature --groupName Configuration --productDescription product-description.md": {
             code: 0,
         },
-        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Gherkin/ChildOfTag.feature --groupName Gherkin": {
+        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Gherkin/ChildOfTag.feature --groupName Gherkin --productDescription product-description.md": {
             code: 0,
         },
     }

--- a/src/build-task/AugurkCLI/tests/publish.ts
+++ b/src/build-task/AugurkCLI/tests/publish.ts
@@ -31,10 +31,10 @@ tmr.setAnswers({
         "/some/path/to/augurk": true
     },
     exec: {
-        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Configuration/RetentionPolicy.feature --groupName Configuration --productDescription product-description.md": {
+        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Configuration/RetentionPolicy.feature --groupName Configuration --productDesc product-description.md": {
             code: 0,
         },
-        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Gherkin/ChildOfTag.feature --groupName Gherkin --productDescription product-description.md": {
+        "/some/path/to/augurk publish --url https://some.augurk.instance --productName Augurk --featureFiles Gherkin/ChildOfTag.feature --groupName Gherkin --productDesc product-description.md": {
             code: 0,
         },
     }


### PR DESCRIPTION
In the process of converting the build tasks to TypeScript based so they can run cross-platform we forget to include the feature to publish a product description markdown file to Augurk. Although the inputs were there in the build task, they weren't being used in the call to the command line, thus they were never published.

Additionally a note was added to the group name input to indicate that it is required for the publish command, but not for the others. This was tripping up users.

Fixes #11 