### PR TITLE
Properly handle version numbers with special characters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ steps:
   condition: succeededOrFailed()
   inputs:
     testRunner: JUnit
-    testResultsFiles: '**/TEST-RESULTS.xml'
+    testResultsFiles: '**/test-results.xml'
     mergeTestResults: true
 
 - task: CopyFiles@2

--- a/src/build-task/AugurkCLI/tests/_suite.ts
+++ b/src/build-task/AugurkCLI/tests/_suite.ts
@@ -19,7 +19,7 @@ describe('Augurk CLI Task', function () {
         });
 
         it ('should succesfully publish with a version', function(done: MochaDone) {
-            this.timeout(1000);
+            this.timeout(2000);
 
             let tp = path.join(__dirname, 'publish-version.js');
             let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -32,7 +32,7 @@ describe('Augurk CLI Task', function () {
         });
     
         it('should succesfully publish an individual group', function(done: MochaDone) {
-            this.timeout(1000);
+            this.timeout(2000);
         
             let tp = path.join(__dirname, 'publish-individual-group.js');
             let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/src/build-task/AugurkCLIInstaller/cli-installer.ts
+++ b/src/build-task/AugurkCLIInstaller/cli-installer.ts
@@ -1,7 +1,5 @@
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
-import * as fs from 'fs';
-import * as path from 'path';
 
 async function run() {
     try {
@@ -31,7 +29,8 @@ async function run() {
         let toolPath: string = toolLib.findLocalTool('augurk-cli', version, platform);
         if (!toolPath) {
             // Tool is not installed, so construct the download URL
-            const url = `https://github.com/Augurk/Augurk.CommandLine/releases/download/${version}/Augurk.CommandLine-${platform}-${version}.${extension}`;
+            const safeVersion = encodeURIComponent(version);
+            const url = `https://github.com/Augurk/Augurk.CommandLine/releases/download/${safeVersion}/Augurk.CommandLine-${platform}-${version.replace("+", ".")}.${extension}`;
 
             // Download the NuGet package and extract it
             const temp: string = await toolLib.downloadTool(url);

--- a/src/build-task/AugurkCLIInstaller/task.json
+++ b/src/build-task/AugurkCLIInstaller/task.json
@@ -8,7 +8,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "capabilities": [
         "augurk-cli"


### PR DESCRIPTION
In some cases version numbers contain special characters, for example when using the full Semantic Versioning 2.0 strategy. Unfortunately this wasn't properly supported by the extension because it didn't properly encode the URL so it wasn't able to download the version from GitHub. This PR fixes that.